### PR TITLE
Rev to 1.1.1-SNAPSHOT

### DIFF
--- a/ids-api/pom.xml
+++ b/ids-api/pom.xml
@@ -8,6 +8,6 @@
     <relativePath/>
   </parent>
   <artifactId>ids-api</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 </project>

--- a/ids-client/pom.xml
+++ b/ids-client/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>ids-client</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <jacoco.coverage>0.90</jacoco.coverage>

--- a/ids-tests/pom.xml
+++ b/ids-tests/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>ids-tests</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <groups>gov.va.api.health.sentinel.categories.Local</groups>
@@ -18,13 +18,13 @@
     <dependency>
       <groupId>gov.va.api.health</groupId>
       <artifactId>ids</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>gov.va.api.health</groupId>
       <artifactId>ids-api</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>gov.va.dvp</groupId>

--- a/ids/pom.xml
+++ b/ids/pom.xml
@@ -8,7 +8,7 @@
     <relativePath/>
   </parent>
   <artifactId>ids</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <mysql-connector-java.version>6.0.6</mysql-connector-java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1.2</version>
   </parent>
   <artifactId>ids-parent</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>ids-api</module>


### PR DESCRIPTION
Due to a repo configuration error with LibertyBot's permissions, versions were not updated after the `1.1.0` release. Since the `1.1.0` artifacts have been published, this PR manually revs the version.