### PR TITLE
Use parent 2.0.0.

### DIFF
--- a/ids-api/pom.xml
+++ b/ids-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
   <artifactId>ids-api</artifactId>

--- a/ids-client/pom.xml
+++ b/ids-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
   <artifactId>ids-client</artifactId>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>gov.va.api.health</groupId>
       <artifactId>service-auto-config</artifactId>
-      <version>1.1.2</version>
+      <version>2.0.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/ids-tests/pom.xml
+++ b/ids-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
   <artifactId>ids-tests</artifactId>

--- a/ids/pom.xml
+++ b/ids/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
     <relativePath/>
   </parent>
   <artifactId>ids</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>1.1.2</version>
+    <version>2.0.0</version>
   </parent>
   <artifactId>ids-parent</artifactId>
   <version>1.1.2-SNAPSHOT</version>


### PR DESCRIPTION
Use latest parent `2.0.0`. More info [here](https://github.com/department-of-veterans-affairs/health-apis-parent/pull/4).