### PR TITLE
Fix client corrupting the RestTemplate

### DIFF
--- a/ids-api/pom.xml
+++ b/ids-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.11</version>
     <relativePath/>
   </parent>
   <artifactId>ids-api</artifactId>

--- a/ids-client/pom.xml
+++ b/ids-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.11</version>
     <relativePath/>
   </parent>
   <artifactId>ids-client</artifactId>

--- a/ids-client/src/main/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfig.java
+++ b/ids-client/src/main/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfig.java
@@ -21,8 +21,13 @@ public class RestIdentityServiceClientConfig {
   @Value("${identityservice.url}")
   private final String url;
 
+  /** Create a new IdentityService that uses REST for communication. */
   @Bean
   public IdentityService restIdentityServiceClient() {
-    return RestIdentityServiceClient.builder().restTemplate(restTemplate).url(url).build();
+    return RestIdentityServiceClient.builder()
+        .baseRestTemplate(restTemplate)
+        .newRestTemplateSupplier(RestTemplate::new)
+        .url(url)
+        .build();
   }
 }

--- a/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfigTest.java
+++ b/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfigTest.java
@@ -1,0 +1,19 @@
+package gov.va.api.health.ids.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gov.va.api.health.ids.api.IdentityService;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.web.client.RestTemplate;
+
+public class RestIdentityServiceClientConfigTest {
+
+  @Test
+  public void restIdentityServiceClient() {
+    RestTemplate rt = Mockito.mock(RestTemplate.class);
+    IdentityService ids =
+        new RestIdentityServiceClientConfig(rt, "http://example.com").restIdentityServiceClient();
+    assertThat(ids).isNotNull();
+  }
+}

--- a/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientTest.java
+++ b/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientTest.java
@@ -76,7 +76,7 @@ public class RestIdentityServiceClientTest {
 
   @SneakyThrows
   @Test()
-  public void lookupErrorHanderAllowsOk() {
+  public void lookupErrorHandlerAllowsOk() {
     ClientHttpResponse r = mock(ClientHttpResponse.class);
     when(r.getStatusCode()).thenReturn(HttpStatus.OK);
     LookupErrorHandler h = new LookupErrorHandler("x");
@@ -86,7 +86,7 @@ public class RestIdentityServiceClientTest {
 
   @SneakyThrows
   @Test(expected = UnknownIdentity.class)
-  public void lookupErrorHanderHandlesNotFound() {
+  public void lookupErrorHandlerHandlesNotFound() {
     ClientHttpResponse r = mock(ClientHttpResponse.class);
     when(r.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
     LookupErrorHandler h = new LookupErrorHandler("x");
@@ -96,7 +96,7 @@ public class RestIdentityServiceClientTest {
 
   @SneakyThrows
   @Test(expected = LookupFailed.class)
-  public void lookupErrorHanderHandlesNotOk() {
+  public void lookupErrorHandlerHandlesNotOk() {
     ClientHttpResponse r = mock(ClientHttpResponse.class);
     when(r.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
     LookupErrorHandler h = new LookupErrorHandler("x");
@@ -151,7 +151,7 @@ public class RestIdentityServiceClientTest {
 
   @SneakyThrows
   @Test()
-  public void registerErrorHanderAllowsOk() {
+  public void registerErrorHandlerAllowsOk() {
     ClientHttpResponse r = mock(ClientHttpResponse.class);
     when(r.getStatusCode()).thenReturn(HttpStatus.OK);
     RegisterErrorHandler h = new RegisterErrorHandler();
@@ -161,7 +161,7 @@ public class RestIdentityServiceClientTest {
 
   @SneakyThrows
   @Test(expected = RegistrationFailed.class)
-  public void registerErrorHanderHandlesNotOk() {
+  public void registerErrorHandlerHandlesNotOk() {
     ClientHttpResponse r = mock(ClientHttpResponse.class);
     when(r.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
     RegisterErrorHandler h = new RegisterErrorHandler();

--- a/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientTest.java
+++ b/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientTest.java
@@ -34,13 +34,15 @@ import org.springframework.web.client.RestTemplate;
 @SuppressWarnings("unchecked")
 public class RestIdentityServiceClientTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
+  @Mock RestTemplate baseRestTemplate;
   @Mock RestTemplate restTemplate;
   private RestIdentityServiceClient client;
 
   @Before
   public void _init() {
     MockitoAnnotations.initMocks(this);
-    client = new RestIdentityServiceClient(restTemplate, "http://whatever.com");
+    client =
+        new RestIdentityServiceClient(baseRestTemplate, "http://whatever.com", () -> restTemplate);
   }
 
   @SneakyThrows
@@ -70,6 +72,36 @@ public class RestIdentityServiceClientTest {
     ResourceIdentity b = a.toBuilder().identifier("b").build();
     ResourceIdentity c = a.toBuilder().identifier("c").build();
     return Arrays.asList(a, b, c);
+  }
+
+  @SneakyThrows
+  @Test()
+  public void lookupErrorHanderAllowsOk() {
+    ClientHttpResponse r = mock(ClientHttpResponse.class);
+    when(r.getStatusCode()).thenReturn(HttpStatus.OK);
+    LookupErrorHandler h = new LookupErrorHandler("x");
+    assertThat(h.hasError(r)).isFalse();
+    h.handleError(r);
+  }
+
+  @SneakyThrows
+  @Test(expected = UnknownIdentity.class)
+  public void lookupErrorHanderHandlesNotFound() {
+    ClientHttpResponse r = mock(ClientHttpResponse.class);
+    when(r.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);
+    LookupErrorHandler h = new LookupErrorHandler("x");
+    assertThat(h.hasError(r)).isTrue();
+    h.handleError(r);
+  }
+
+  @SneakyThrows
+  @Test(expected = LookupFailed.class)
+  public void lookupErrorHanderHandlesNotOk() {
+    ClientHttpResponse r = mock(ClientHttpResponse.class);
+    when(r.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+    LookupErrorHandler h = new LookupErrorHandler("x");
+    assertThat(h.hasError(r)).isTrue();
+    h.handleError(r);
   }
 
   @Test
@@ -115,6 +147,26 @@ public class RestIdentityServiceClientTest {
             Mockito.any(HttpEntity.class),
             Mockito.any(ParameterizedTypeReference.class)))
         .thenReturn(new ResponseEntity<>(body, status));
+  }
+
+  @SneakyThrows
+  @Test()
+  public void registerErrorHanderAllowsOk() {
+    ClientHttpResponse r = mock(ClientHttpResponse.class);
+    when(r.getStatusCode()).thenReturn(HttpStatus.OK);
+    RegisterErrorHandler h = new RegisterErrorHandler();
+    assertThat(h.hasError(r)).isFalse();
+    h.handleError(r);
+  }
+
+  @SneakyThrows
+  @Test(expected = RegistrationFailed.class)
+  public void registerErrorHanderHandlesNotOk() {
+    ClientHttpResponse r = mock(ClientHttpResponse.class);
+    when(r.getStatusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
+    RegisterErrorHandler h = new RegisterErrorHandler();
+    assertThat(h.hasError(r)).isTrue();
+    h.handleError(r);
   }
 
   @Test

--- a/ids-tests/pom.xml
+++ b/ids-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>test-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.11</version>
     <relativePath/>
   </parent>
   <artifactId>ids-tests</artifactId>

--- a/ids/pom.xml
+++ b/ids/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>service-starter</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.11</version>
     <relativePath/>
   </parent>
   <artifactId>ids</artifactId>

--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,2 @@
 lombok.accessors.fluent=true
+lombok.addLombokGeneratedAnnotation=true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.11</version>
   </parent>
   <artifactId>ids-parent</artifactId>
   <version>1.1.3-SNAPSHOT</version>


### PR DESCRIPTION
Do this first: https://github.com/department-of-veterans-affairs/health-apis-parent/pull/17

Addresses an issue where the IdentityService REST client would corrupt the RestTemplate used by multiple threads