### PR TITLE
IDS client will no longer lookup IDs formatted in an unknown ID as unknown

### DIFF
--- a/ids-client/src/main/java/gov/va/api/health/ids/client/IdEncoder.java
+++ b/ids-client/src/main/java/gov/va/api/health/ids/client/IdEncoder.java
@@ -16,6 +16,10 @@ public interface IdEncoder {
     public BadId(String message, Throwable cause) {
       super(message, cause);
     }
+
+    public BadId(String message) {
+      super(message, null);
+    }
   }
 
   /** Parent for all IdEncoder exceptions. */

--- a/ids-client/src/main/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfig.java
+++ b/ids-client/src/main/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfig.java
@@ -31,6 +31,9 @@ public class RestIdentityServiceClientConfig {
   @Value("${identityservice.encodingKey:disabled}")
   private final String encodingKey;
 
+  @Value("${identityservice.patientIdPattern:[0-9]{10}V[0-9]{6}}")
+  private final String patientIdPattern;
+
   private RestIdentityServiceClient createRestIdentityServiceClient() {
     /*
      * This is extracted with out the Spring annotation so it can be re-used without causing an
@@ -55,10 +58,11 @@ public class RestIdentityServiceClientConfig {
       log.info("Encoding Identity Service has been disabled.");
       return createRestIdentityServiceClient();
     }
-    log.info("Using encoding Identity Service");
+    log.info("Using encoding Identity Service with patient ID pattern '{}'", patientIdPattern);
     return EncodingIdentityServiceClient.builder()
         .encoder(EncryptingIdEncoder.builder().password(encodingKey).codebook(codebook).build())
         .delegate(createRestIdentityServiceClient())
+        .patientIdPattern(patientIdPattern)
         .build();
   }
 

--- a/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfigTest.java
+++ b/ids-client/src/test/java/gov/va/api/health/ids/client/RestIdentityServiceClientConfigTest.java
@@ -14,7 +14,7 @@ public class RestIdentityServiceClientConfigTest {
   public void encodingIdentityServiceClientUsesEncodingClientIfPasswordIsSet() {
     RestTemplate rt = Mockito.mock(RestTemplate.class);
     IdentityService ids =
-        new RestIdentityServiceClientConfig(rt, "http://example.com", "secret")
+        new RestIdentityServiceClientConfig(rt, "http://example.com", "secret", ".*")
             .encodingIdentityServiceClient(Codebook.builder().build());
     assertThat(ids).isInstanceOf(EncodingIdentityServiceClient.class);
   }
@@ -23,7 +23,7 @@ public class RestIdentityServiceClientConfigTest {
   public void restIdentityServiceClientCanBeUsed() {
     RestTemplate rt = Mockito.mock(RestTemplate.class);
     IdentityService ids =
-        new RestIdentityServiceClientConfig(rt, "http://example.com", "secret")
+        new RestIdentityServiceClientConfig(rt, "http://example.com", "secret", ".*")
             .restIdentityServiceClient();
     assertThat(ids).isInstanceOf(RestIdentityServiceClient.class);
   }
@@ -32,11 +32,11 @@ public class RestIdentityServiceClientConfigTest {
   public void restIdentityServiceClientUsesEncodingClientIfPasswordIsNotSet() {
     RestTemplate rt = Mockito.mock(RestTemplate.class);
     IdentityService ids =
-        new RestIdentityServiceClientConfig(rt, "http://example.com", "")
+        new RestIdentityServiceClientConfig(rt, "http://example.com", "", ".*")
             .encodingIdentityServiceClient(Codebook.builder().build());
     assertThat(ids).isInstanceOf(RestIdentityServiceClient.class);
     ids =
-        new RestIdentityServiceClientConfig(rt, "http://example.com", "disabled")
+        new RestIdentityServiceClientConfig(rt, "http://example.com", "disabled", ".*")
             .encodingIdentityServiceClient(Codebook.builder().build());
     assertThat(ids).isInstanceOf(RestIdentityServiceClient.class);
   }


### PR DESCRIPTION
"UNKNOWN UNKNOWN <id>".

Instead, it will throw an exception indicating that the ID is bad and cannot be looked up.