### PR TITLE
`encoded-ids` tool support for switching between I2 and I3 ids. Mapping jar is no longer required. If not specified, no component expansion will be performed.

### DIFF
--- a/ids-client/encoded-id
+++ b/ids-client/encoded-id
@@ -1,13 +1,30 @@
 #!/usr/bin/env bash
-
-
 BASE_DIR=$(dirname $(readlink -f $0))
 
+usage() {
+cat<<EOF
+$0 [options] <encoded-id>|<system> <resource> <id>
+
+Encode or decode the given ID.
+
+Options:
+-p, --password <secret>
+  The password to use when encoding or decoding the ID.
+-m, --mapping <jar>
+  A jar with a Codebook Supplier that will be used to expand/compress ID components.
+-2, --i2
+  Enable only I2 support
+-3, --i3
+  Enable only I3 support
+
+${1:-}
+EOF
+exit 1
+}
 
 findToolsJar() {
   IDS_TOOLS_JAR=$(find $BASE_DIR/target -name "ids-client-*-tools.jar")
 }
-
 
 findToolsJar
 
@@ -21,9 +38,12 @@ fi
 
 [ -n "$JAVA_HOME" ] && JAVA_EXE="$JAVA_HOME/bin/java" || JAVA_EXE=java
 
+
+I2=${I2:-true}
+I3=${I3:-true}
 ARGS=$(getopt -n $(basename ${0}) \
-  -l "debug,help,mapping:,password:" \
-    -o "hm:p:" -- "$@")
+  -l "debug,help,mapping:,password:,i2,i3" \
+    -o "hm:p:23" -- "$@")
 [ $? != 0 ] && usage
 eval set -- "$ARGS"
 while true
@@ -32,6 +52,8 @@ do
     --debug) set -x;;
     -p|--password) export IDS_PASSWORD="$2";;
     -m|--mapping) export IDS_MAPPING_JAR="$2";;
+    -3|--i3) I2=false; I3=true;;
+    -2|--i2) I2=true; I3=false;;
     -h|--help) usage "halp! what this do?";;
     --) shift;break;;
   esac
@@ -39,9 +61,7 @@ do
 done
 
 
-[ -z "$IDS_PASSWORD" ] && echo "Password not specified" && exit 1
-
-[ -z "$IDS_MAPPING_JAR" ] && echo "Mapping not specified" && exit 1
+[ -z "$IDS_PASSWORD" ] && usage "Password not specified"
 
 CLASSPATH="${IDS_TOOLS_JAR}:${IDS_MAPPING_JAR}"
 
@@ -51,7 +71,9 @@ then
 fi
 
 $JAVA_EXE \
-  -Dpassword="$IDS_PASSWORD" \
   -cp "${CLASSPATH}" \
+  -Dpassword="$IDS_PASSWORD" \
+  -Di2=$I2 \
+  -Di3=$I3 \
   gov.va.api.health.ids.client.Tools \
   $@

--- a/ids-client/src/main/java/gov/va/api/health/ids/client/Tools.java
+++ b/ids-client/src/main/java/gov/va/api/health/ids/client/Tools.java
@@ -1,15 +1,23 @@
 package gov.va.api.health.ids.client;
 
-import static gov.va.api.health.ids.client.EncodedIdFormat.V2_PREFIX;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import gov.va.api.health.ids.api.IdentityService;
 import gov.va.api.health.ids.api.ResourceIdentity;
 import gov.va.api.health.ids.client.EncryptingIdEncoder.Codebook;
 import gov.va.api.health.ids.client.EncryptingIdEncoder.CodebookSupplier;
+import gov.va.api.health.ids.client.IdsClientProperties.EncodedIdsFormatProperties;
+import gov.va.api.health.ids.client.IdsClientProperties.PatientIcnFormatProperties;
+import gov.va.api.health.ids.client.IdsClientProperties.UuidFormatProperties;
 import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
+import org.slf4j.LoggerFactory;
 
 @NoArgsConstructor(staticName = "tools")
 public class Tools {
@@ -19,6 +27,13 @@ public class Tools {
 
   /** Tool main called from command line. */
   public static void main(String[] args) {
+    try {
+      LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+      Logger rootLogger = lc.getLogger(Logger.ROOT_LOGGER_NAME);
+      rootLogger.setLevel(Level.OFF);
+    } catch (Exception e) {
+      // ignored... we tried to disabled logging.
+    }
     if (args.length == 1) {
       tools().decode(args[0]);
     } else if (args.length == 3) {
@@ -41,28 +56,51 @@ public class Tools {
   }
 
   private void decode(String id) {
-    ResourceIdentity identity = encoder().decode(id.replace(V2_PREFIX, ""));
+    List<ResourceIdentity> identities = encoder().lookup(id);
+    if (identities.isEmpty()) {
+      throw new IllegalArgumentException("Cannot determine identity of " + id);
+    }
+    ResourceIdentity identity = identities.get(0);
     System.out.println(identity.system() + " " + identity.resource() + " " + identity.identifier());
+  }
+
+  private boolean enabled(String property) {
+    return BooleanUtils.toBoolean(System.getProperty(property, "true"));
   }
 
   private void encode(String system, String resource, String identifier) {
     System.out.println(
-        V2_PREFIX
-            + encoder()
-                .encode(
+        encoder()
+            .register(
+                List.of(
                     ResourceIdentity.builder()
                         .system(system)
                         .resource(resource)
                         .identifier(identifier)
-                        .build()));
+                        .build()))
+            .get(0)
+            .uuid());
   }
 
-  private EncryptingIdEncoder encoder() {
+  private IdentityService encoder() {
+    var properties =
+        IdsClientProperties.builder()
+            .patientIcn(
+                PatientIcnFormatProperties.builder()
+                    .enabled(enabled("patient"))
+                    .idPattern("[0-9]+(V[0-9]{6})?")
+                    .build())
+            .encodedIds(
+                EncodedIdsFormatProperties.builder()
+                    .i2Enabled(enabled("i2"))
+                    .i3Enabled(enabled("i3"))
+                    .encodingKey(password())
+                    .build())
+            .uuid(UuidFormatProperties.builder().enabled(false).build())
+            .build();
+    var config = new RestIdentityServiceClientConfig(null, properties, null);
     Optional<CodebookSupplier> codebooks = ServiceLoader.load(CodebookSupplier.class).findFirst();
-    return EncryptingIdEncoder.builder()
-        .password(password())
-        .codebook(codebooks.orElseGet(EmptyCodebookSupplier::new).get())
-        .build();
+    return config.encodingIdentityServiceClient(codebooks.orElse(Codebook::empty).get());
   }
 
   private String password() {
@@ -75,13 +113,6 @@ public class Tools {
       throw new MissingProperty(name);
     }
     return value;
-  }
-
-  private static class EmptyCodebookSupplier implements CodebookSupplier {
-    @Override
-    public Codebook get() {
-      return Codebook.builder().build();
-    }
   }
 
   static final class MissingProperty extends RuntimeException {


### PR DESCRIPTION
By default both 2 and 3 are enabled, but can refined with `--i2` and `--i3` switches.

Furthermore, dynamic switching based on the IDs used by Data Query and Vista Fhir Query can be done with following function, replacing the location of jars with something that makes sense for you.

```
function eid() {
  local mapping
  if [[ "${1:-}" = I2* || "${1:-}" = C* ]]; then mapping="-2 -m $(find ~/va/dq/health-apis-data-query -name "data-query-ids-mapping-*.jar" | head -1)"; fi
  if [[ "${1:-}" = I3* || "${1:-}" = V* ]]; then mapping="-3 -m $(find ~/va/vl/health-apis-vista-fhir-query -name "vista-fhir-query-ids-mapping-*.jar" | head -1)"; fi
  ~/va/dq/health-apis-ids/ids-client/encoded-id $mapping $@
}
```
